### PR TITLE
[fix] es6-promise as standard dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "module": "lib/app.js",
   "types": "lib/app.d.ts",
   "dependencies": {
+    "es6-promise": "^4.2.4",
     "axios": "^0.18.0",
     "bootstrap": "^4.1.3",
     "cookie": "^0.3.1",
@@ -36,7 +37,6 @@
     "copy-webpack-plugin": "^4.5.2",
     "css-loader": "0.28.11",
     "decko": "^1.2.0",
-    "es6-promise": "^4.2.4",
     "eslint": "3.0.0",
     "eslint-loader": "2.0.0",
     "eslint-plugin-import": "1.16.0",


### PR DESCRIPTION
es6-promise seems to include a polyfill for IE11, which we need for
certain customers